### PR TITLE
Add check to update the stripPrefix path if on Windows machine

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = bundler => {
     const isWin = /^win/.test(process.platform);
     let stripPrefixDefault = outDir + '/';
     if (isWin) {
-      stripPrefixDefault = stripPrefix.replace(/\\/g, '/');
+      stripPrefixDefault = stripPrefixDefault.replace(/\\/g, '/');
     }
 
     const options = {

--- a/index.js
+++ b/index.js
@@ -50,6 +50,12 @@ module.exports = bundler => {
       ...swPrecacheConfigs
     }
 
+    // Update stripPrefix for Windows file path format
+    const isWin = /^win/.test(process.platform);
+    if (isWin) {
+      options.stripPrefix = options.stripPrefix.replace(/\\/g, '/');
+    }
+
     getServiceWorkder(options).then(codes => {
       const fileName = 'service-worker.js'
       if (minify) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,15 @@ module.exports = bundler => {
       pkg = bundler.mainBundle.entryAsset.package
     }
 
-    const swPrecacheConfigs = pkg['sw-precache']
+    const swPrecacheConfigs = pkg['sw-precache'];
+
+    // Update default stripPrefix for Windows file path format
+    const isWin = /^win/.test(process.platform);
+    let stripPrefixDefault = outDir + '/';
+    if (isWin) {
+      stripPrefixDefault = stripPrefix.replace(/\\/g, '/');
+    }
+
     const options = {
       cacheId: pkg.name, // default cacheId
 
@@ -40,7 +48,7 @@ module.exports = bundler => {
         /service-worker\.js$/
       ],
 
-      stripPrefix: outDir + '/',
+      stripPrefix: stripPrefixDefault,
       replacePrefix: urlJoin(publicURL, '/'),
 
       // https://firebase.google.com/docs/hosting/reserved-urls#reserved_urls_and_service_workers
@@ -48,12 +56,6 @@ module.exports = bundler => {
 
       // merge user configs
       ...swPrecacheConfigs
-    }
-
-    // Update stripPrefix for Windows file path format
-    const isWin = /^win/.test(process.platform);
-    if (isWin) {
-      options.stripPrefix = options.stripPrefix.replace(/\\/g, '/');
     }
 
     getServiceWorkder(options).then(codes => {


### PR DESCRIPTION
## Description
Due to the file/folder path format changes between POSIX and Windows machine, the stripPrefix option of the plugin is not matched accordingly.

**Observed in:** Windows 10 machine

## How Has This Been Tested?
Prepared the service worker for a project that uses parcel for bundling and verified the service worker file(output) whether the path is properly updated.