### PR TITLE
feat: use new getPackage method from parcel-bundler

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,39 +9,27 @@ const getServiceWorkder = options =>
     throw err
   })
 
+const getValue = function (obj, key) {
+  return key.split('.').reduce(function (o, x) {
+    return (typeof o == 'undefined' || o === null) ? o : o[x];
+  }, obj);
+}
+
 module.exports = bundler => {
-  const { minify, publicURL, outDir } = bundler.options
+  const {
+    minify,
+    publicURL,
+    outDir
+  } = bundler.options
 
   bundler.on('bundled', async () => {
     let pkg
-    let mainAssetPackage
+    const entryAsset = getValue(bundler, 'mainBundle.entryAsset')
 
-    if (bundler.mainAsset) {
-      if (bundler.mainAsset.getPackage) {
-        mainAssetPackage = await bundler.mainAsset.getPackage()
-      } else {
-        mainAssetPackage = bundler.mainAsset.package
-      }
-    }
-
-    if (
-      mainAssetPackage &&
-      mainAssetPackage.pkgfile
-    ) {
-      // for parcel-bundler version@<1.8
-      pkg = require(mainAssetPackage.pkgfile)
-    } else {
-      let mainBundlePackage
-
-      if (bundler.mainBundle &&
-        bundler.mainBundle.entryAsset) {
-        if (bundler.mainBundle.entryAsset.getPackage) {
-          mainBundlePackage = await bundler.mainBundle.entryAsset.getPackage()
+    if (entryAsset) {
+      pkg = await entryAsset.getPackage()
         } else {
-          mainBundlePackage = bundler.mainBundle.entryAsset.package
-        }
-      }
-      pkg = await mainBundlePackage
+      throw new Error('The bundler properties/sub-properties (mainBundle / entryAsset) seems to be not present')
     }
 
     const swPrecacheConfigs = pkg['sw-precache']

--- a/index.js
+++ b/index.js
@@ -12,17 +12,36 @@ const getServiceWorkder = options =>
 module.exports = bundler => {
   const { minify, publicURL, outDir } = bundler.options
 
-  bundler.on('bundled', () => {
+  bundler.on('bundled', async () => {
     let pkg
+    let mainAssetPackage
+
+    if (bundler.mainAsset) {
+      if (bundler.mainAsset.getPackage) {
+        mainAssetPackage = await bundler.mainAsset.getPackage()
+      } else {
+        mainAssetPackage = bundler.mainAsset.package
+      }
+    }
+
     if (
-      bundler.mainAsset &&
-      bundler.mainAsset.package &&
-      bundler.mainAsset.package.pkgfile
+      mainAssetPackage &&
+      mainAssetPackage.pkgfile
     ) {
       // for parcel-bundler version@<1.8
-      pkg = require(bundler.mainAsset.package.pkgfile)
+      pkg = require(mainAssetPackage.pkgfile)
     } else {
-      pkg = bundler.mainBundle.entryAsset.package
+      let mainBundlePackage
+
+      if (bundler.mainBundle &&
+        bundler.mainBundle.entryAsset) {
+        if (bundler.mainBundle.entryAsset.getPackage) {
+          mainBundlePackage = await bundler.mainBundle.entryAsset.getPackage()
+        } else {
+          mainBundlePackage = bundler.mainBundle.entryAsset.package
+        }
+      }
+      pkg = await mainBundlePackage
     }
 
     const swPrecacheConfigs = pkg['sw-precache']

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pwa"
   ],
   "peerDependencies": {
-    "parcel-bundler": "^1.8.1"
+    "parcel-bundler": "^1.9.7"
   },
   "dependencies": {
     "sw-precache": "^5.2.1",


### PR DESCRIPTION
This commit aims to remove the deprecated message:
"`asset.package` is deprecated. Please use
`await asset.getPackage()` instead." when bundling.

The bundled event function is now async and it awaits the `getPackage()` method calls or falls back into former `package` property if it doesn't exist.