### PR TITLE
Add wasm to list of cacheable file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = bundler => {
       dontCacheBustUrlsMatching: /\.\w{8}\./,
       navigateFallback: urlJoin(publicURL, 'index.html'),
       staticFileGlobs: [
-        outDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff,woff2,ogg,wav,mp3}'
+        outDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff,woff2,ogg,wav,mp3,wasm}'
       ],
       staticFileGlobsIgnorePatterns: [
         /\.map$/,


### PR DESCRIPTION
Hi!

Cool plugin! However, I was trying to use it with a project partially written in wasm and wondered why them .wasm files were not cached. Turned out they are simply missing in the list of file extensions. I've added them!