### PR TITLE
add pdf to the extensions allowed to be precached

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = bundler => {
       dontCacheBustUrlsMatching: /\.\w{8}\./,
       navigateFallback: urlJoin(publicURL, 'index.html'),
       staticFileGlobs: [
-        outDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff,woff2,ogg,wav,mp3,wasm,webp}'
+        outDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff,woff2,ogg,wav,mp3,wasm,webp,pdf}'
       ],
       staticFileGlobsIgnorePatterns: [
         /\.map$/,

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,8 @@ For example:
   }
 }
 ```
+**Note:** only files with the following extensions will be added to the precache :
+`js, html, css, png, jpg, gif, svg, eot, ttf, woff, woff2, ogg, wav, mp3, wasm, webp, pdf`
 
 ### License
 


### PR DESCRIPTION
## Summary

When we use a pdf file in our code, the plugin does not include it in the precache variable of the service worker.


## Things done in this PR

- [x] add extension `pdf` to the supported extensions
- [x] add a note in the readme about the supported extensions

## Does this PR introduce a breaking change? **No**
